### PR TITLE
switch CI and docker compose to use main vs master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: ${{github.ref == 'refs/heads/master' || github.ref == 'refs/heads/arch-v3' || github.event.ref_type == 'tag' }}
+          push: ${{github.ref == 'refs/heads/main' || github.ref == 'refs/heads/arch-v3' || github.event.ref_type == 'tag' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           target: cht-couch2pg

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - ${POSTGRES_PORT:-5432}:5432
 
   cht-couch2pg:
-    image: medicmobile/cht-couch2pg:master-node-10
+    image: medicmobile/cht-couch2pg:main-node-10
     environment:
       COUCHDB_URL: ${COUCHDB_URL:-https://medic:password@localhost:5988/medic}
 


### PR DESCRIPTION
This PR one problem and then accounts for the fix:
* Change CI to not look for `master` but look for `main` instead.  This means that the the tag pushed to docker hub will be `main-node-VERSION` instead of `master-node-VERSION` (eg `main-node-10` vs `master-node-10`)
* Change docker-compose file to use new nomenclature for hub image name

 per #119 