### PR TITLE
Improved useviews for telemetry metrics and telemetry devices

### DIFF
--- a/libs/medic-users-meta/migrations/202304140052.do.telemetry_devices.sql
+++ b/libs/medic-users-meta/migrations/202304140052.do.telemetry_devices.sql
@@ -5,6 +5,8 @@ TABLESPACE pg_default AS
 
 SELECT
   DISTINCT ON (doc #>> '{metadata,deviceId}', doc #>> '{metadata,user}')
+  
+  doc #>> '{_id}' AS telemetry_doc_id,
   doc #>> '{metadata,deviceId}' AS device_id,
   doc #>> '{metadata,user}' AS user_name,
   
@@ -29,7 +31,6 @@ SELECT
   )::date AS period_start,
     
 
-  doc #>> '{_id}' AS telemetry_doc_id,
   doc #>> '{device,deviceInfo,hardware,manufacturer}' AS device_manufacturer,
   doc #>> '{device,deviceInfo,hardware,model}' AS device_model,
   

--- a/libs/medic-users-meta/migrations/202304140052.do.telemetry_devices.sql
+++ b/libs/medic-users-meta/migrations/202304140052.do.telemetry_devices.sql
@@ -1,0 +1,47 @@
+DROP MATERIALIZED VIEW IF EXISTS useview_telemetry_devices;
+
+CREATE MATERIALIZED VIEW public.useview_telemetry_metrics
+TABLESPACE pg_default AS 
+
+WITH telemetry_docs_with_metric_blob AS (
+ SELECT
+    doc #>> '{metadata,deviceId}' AS device_id,
+    doc #>> '{_id}' AS telemetry_doc_id,
+    doc #>> '{metadata,user}' AS user_name,
+    concat_ws(
+      '-', doc #>> '{metadata,year}',
+      CASE
+          WHEN (doc #>> '{metadata,day}') IS NULL AND ((doc #>> '{metadata,versions,app}') IS NULL OR string_to_array("substring"(doc #>> '{metadata,versions,app}', '(\d+.\d+.\d+)'::text), '.'::text)::integer[] < '{3,8,0}'::integer[]) THEN ((doc #>> '{metadata,month}')::integer) + 1
+          ELSE (doc #>> '{metadata,month}')::integer
+      END,
+      CASE
+          WHEN (doc #>> '{metadata,day}') IS NOT NULL THEN doc #>> '{metadata,day}'
+          ELSE '1'::text
+      END
+    )::date AS period_start,
+    jsonb_object_keys(doc -> 'metrics'::text) AS metric,
+    doc -> 'metrics' -> jsonb_object_keys(doc -> 'metrics') AS metric_values
+   FROM couchdb_users_meta
+   WHERE doc ->> 'type' = 'telemetry'
+)
+
+SELECT
+  telemetry_docs_with_metric_blob.device_id,
+  telemetry_docs_with_metric_blob.telemetry_doc_id,
+  telemetry_docs_with_metric_blob.period_start,
+  telemetry_docs_with_metric_blob.user_name,
+  telemetry_docs_with_metric_blob.metric,
+  jsonb_to_record.min,
+  jsonb_to_record.max,
+  jsonb_to_record.sum,
+  jsonb_to_record.count,
+  jsonb_to_record.sumsqr
+FROM telemetry_docs_with_metric_blob
+CROSS JOIN LATERAL jsonb_to_record(telemetry_docs_with_metric_blob.metric_values) jsonb_to_record(min numeric, max numeric, sum numeric, count bigint, sumsqr numeric)
+
+WITH DATA;
+
+CREATE UNIQUE INDEX useview_telemetry_metrics_docid_metric ON public.useview_telemetry_metrics USING btree (telemetry_doc_id, metric);
+CREATE INDEX useview_telemetry_metrics_period_start ON public.useview_telemetry_metrics USING btree (period_start);
+CREATE INDEX useview_telemetry_metrics_device_id ON public.useview_telemetry_metrics USING btree (device_id);
+CREATE INDEX useview_telemetry_metrics_user_name ON public.useview_telemetry_metrics USING btree (user_name);

--- a/libs/medic-users-meta/migrations/202304140052.do.telemetry_devices.sql
+++ b/libs/medic-users-meta/migrations/202304140052.do.telemetry_devices.sql
@@ -1,47 +1,53 @@
 DROP MATERIALIZED VIEW IF EXISTS useview_telemetry_devices;
 
-CREATE MATERIALIZED VIEW public.useview_telemetry_metrics
+CREATE MATERIALIZED VIEW public.useview_telemetry_devices
 TABLESPACE pg_default AS 
 
-WITH telemetry_docs_with_metric_blob AS (
- SELECT
-    doc #>> '{metadata,deviceId}' AS device_id,
-    doc #>> '{_id}' AS telemetry_doc_id,
-    doc #>> '{metadata,user}' AS user_name,
-    concat_ws(
-      '-', doc #>> '{metadata,year}',
-      CASE
-          WHEN (doc #>> '{metadata,day}') IS NULL AND ((doc #>> '{metadata,versions,app}') IS NULL OR string_to_array("substring"(doc #>> '{metadata,versions,app}', '(\d+.\d+.\d+)'::text), '.'::text)::integer[] < '{3,8,0}'::integer[]) THEN ((doc #>> '{metadata,month}')::integer) + 1
-          ELSE (doc #>> '{metadata,month}')::integer
-      END,
-      CASE
-          WHEN (doc #>> '{metadata,day}') IS NOT NULL THEN doc #>> '{metadata,day}'
-          ELSE '1'::text
-      END
-    )::date AS period_start,
-    jsonb_object_keys(doc -> 'metrics'::text) AS metric,
-    doc -> 'metrics' -> jsonb_object_keys(doc -> 'metrics') AS metric_values
-   FROM couchdb_users_meta
-   WHERE doc ->> 'type' = 'telemetry'
-)
-
 SELECT
-  telemetry_docs_with_metric_blob.device_id,
-  telemetry_docs_with_metric_blob.telemetry_doc_id,
-  telemetry_docs_with_metric_blob.period_start,
-  telemetry_docs_with_metric_blob.user_name,
-  telemetry_docs_with_metric_blob.metric,
-  jsonb_to_record.min,
-  jsonb_to_record.max,
-  jsonb_to_record.sum,
-  jsonb_to_record.count,
-  jsonb_to_record.sumsqr
-FROM telemetry_docs_with_metric_blob
-CROSS JOIN LATERAL jsonb_to_record(telemetry_docs_with_metric_blob.metric_values) jsonb_to_record(min numeric, max numeric, sum numeric, count bigint, sumsqr numeric)
+  DISTINCT ON (doc #>> '{metadata,deviceId}', doc #>> '{metadata,user}')
+  doc #>> '{metadata,deviceId}' AS device_id,
+  doc #>> '{metadata,user}' AS user_name,
+  
+  concat_ws(
+    '-',
+    doc #>> '{metadata,year}',
+    CASE
+      WHEN 
+        doc #>> '{metadata,day}' IS NULL 
+        AND (
+          doc #>> '{metadata,versions,app}' IS NULL 
+          OR string_to_array("substring"(doc #>> '{metadata,versions,app}', '(\d+.\d+.\d+)'), '.')::integer[] < '{3,8,0}'::integer[]
+        ) 
+      THEN (doc #>> '{metadata,month}')::integer + 1
+      ELSE (doc #>> '{metadata,month}')::integer
+    END,
+    CASE
+      WHEN doc #>> '{metadata,day}' IS NOT NULL 
+      THEN doc #>> '{metadata,day}'
+      ELSE '1'
+    END
+  )::date AS period_start,
+    
+
+  doc #>> '{_id}' AS telemetry_doc_id,
+  doc #>> '{device,deviceInfo,hardware,manufacturer}' AS device_manufacturer,
+  doc #>> '{device,deviceInfo,hardware,model}' AS device_model,
+  
+  doc #>> '{dbInfo,doc_count}' AS doc_count,
+  doc #>> '{device,userAgent}' AS user_agent,
+  
+  doc #>> '{device,deviceInfo,app,version}' AS cht_android_version,
+  doc #>> '{device,deviceInfo,software,androidVersion}' AS android_version,
+  
+  doc #>> '{device,deviceInfo,storage,free}' AS storage_free,
+  doc #>> '{device,deviceInfo,storage,total}' AS storage_total,
+  
+  doc #>> '{device,deviceInfo,network,upSpeed}' AS network_up_speed,
+  doc #>> '{device,deviceInfo,network,downSpeed}' AS network_down_speed
+FROM couchdb_users_meta
+WHERE doc ->> 'type' = 'telemetry'
+ORDER BY 1, 2, 3 ASC
 
 WITH DATA;
 
-CREATE UNIQUE INDEX useview_telemetry_metrics_docid_metric ON public.useview_telemetry_metrics USING btree (telemetry_doc_id, metric);
-CREATE INDEX useview_telemetry_metrics_period_start ON public.useview_telemetry_metrics USING btree (period_start);
-CREATE INDEX useview_telemetry_metrics_device_id ON public.useview_telemetry_metrics USING btree (device_id);
-CREATE INDEX useview_telemetry_metrics_user_name ON public.useview_telemetry_metrics USING btree (user_name);
+CREATE UNIQUE INDEX useview_telemetry_devices_device_user ON public.useview_telemetry_devices USING btree (device_id, user_name);

--- a/libs/medic-users-meta/migrations/202304140052.do.telemetry_devices.sql
+++ b/libs/medic-users-meta/migrations/202304140052.do.telemetry_devices.sql
@@ -47,7 +47,7 @@ SELECT
   doc #>> '{device,deviceInfo,network,downSpeed}' AS network_down_speed
 FROM couchdb_users_meta
 WHERE doc ->> 'type' = 'telemetry'
-ORDER BY 1, 2, 3 ASC
+ORDER BY 2, 3, 4 ASC
 
 WITH DATA;
 

--- a/libs/medic-users-meta/migrations/202304140054.do.telemetry_metrics.sql
+++ b/libs/medic-users-meta/migrations/202304140054.do.telemetry_metrics.sql
@@ -26,11 +26,12 @@ WITH telemetry_docs_with_metric_blob AS (
 )
 
 SELECT
-  telemetry_docs_with_metric_blob.device_id,
   telemetry_docs_with_metric_blob.telemetry_doc_id,
+  telemetry_docs_with_metric_blob.metric,
+  
   telemetry_docs_with_metric_blob.period_start,
   telemetry_docs_with_metric_blob.user_name,
-  telemetry_docs_with_metric_blob.metric,
+  telemetry_docs_with_metric_blob.device_id,
   jsonb_to_record.min,
   jsonb_to_record.max,
   jsonb_to_record.sum,

--- a/libs/medic-users-meta/migrations/202304140054.do.telemetry_metrics.sql
+++ b/libs/medic-users-meta/migrations/202304140054.do.telemetry_metrics.sql
@@ -1,0 +1,47 @@
+DROP MATERIALIZED VIEW IF EXISTS useview_telemetry_metrics;
+
+CREATE MATERIALIZED VIEW public.useview_telemetry_metrics
+TABLESPACE pg_default AS 
+
+WITH telemetry_docs_with_metric_blob AS (
+ SELECT
+    doc #>> '{metadata,deviceId}' AS device_id,
+    doc #>> '{_id}' AS telemetry_doc_id,
+    doc #>> '{metadata,user}' AS user_name,
+    concat_ws(
+      '-', doc #>> '{metadata,year}',
+      CASE
+          WHEN (doc #>> '{metadata,day}') IS NULL AND ((doc #>> '{metadata,versions,app}') IS NULL OR string_to_array("substring"(doc #>> '{metadata,versions,app}', '(\d+.\d+.\d+)'::text), '.'::text)::integer[] < '{3,8,0}'::integer[]) THEN ((doc #>> '{metadata,month}')::integer) + 1
+          ELSE (doc #>> '{metadata,month}')::integer
+      END,
+      CASE
+          WHEN (doc #>> '{metadata,day}') IS NOT NULL THEN doc #>> '{metadata,day}'
+          ELSE '1'::text
+      END
+    )::date AS period_start,
+    jsonb_object_keys(doc -> 'metrics'::text) AS metric,
+    doc -> 'metrics' -> jsonb_object_keys(doc -> 'metrics') AS metric_values
+   FROM couchdb_users_meta
+   WHERE doc ->> 'type' = 'telemetry'
+)
+
+SELECT
+  telemetry_docs_with_metric_blob.device_id,
+  telemetry_docs_with_metric_blob.telemetry_doc_id,
+  telemetry_docs_with_metric_blob.period_start,
+  telemetry_docs_with_metric_blob.user_name,
+  telemetry_docs_with_metric_blob.metric,
+  jsonb_to_record.min,
+  jsonb_to_record.max,
+  jsonb_to_record.sum,
+  jsonb_to_record.count,
+  jsonb_to_record.sumsqr
+FROM telemetry_docs_with_metric_blob
+CROSS JOIN LATERAL jsonb_to_record(telemetry_docs_with_metric_blob.metric_values) jsonb_to_record(min numeric, max numeric, sum numeric, count bigint, sumsqr numeric)
+
+WITH DATA;
+
+CREATE UNIQUE INDEX useview_telemetry_metrics_docid_metric ON public.useview_telemetry_metrics USING btree (telemetry_doc_id, metric);
+CREATE INDEX useview_telemetry_metrics_period_start ON public.useview_telemetry_metrics USING btree (period_start);
+CREATE INDEX useview_telemetry_metrics_device_id ON public.useview_telemetry_metrics USING btree (device_id);
+CREATE INDEX useview_telemetry_metrics_user_name ON public.useview_telemetry_metrics USING btree (user_name);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cht-couch2pg",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cht-couch2pg",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Replicate CHT data from CouchDB to postgres database",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/tests/replicate_users_meta.js
+++ b/tests/replicate_users_meta.js
@@ -48,6 +48,6 @@ describe('medic users meta db replication', () => {
     const views = await db.matViews();
 
     const viewsNames = views.map(view => view.view_name);
-    expect(viewsNames).to.have.members(['form_metadata', 'contactview_metadata', 'useview_feedback', 'useview_telemetry']);
+    expect(viewsNames).to.have.members(['form_metadata', 'contactview_metadata', 'useview_feedback', 'useview_telemetry', 'useview_telemetry_metrics', 'useview_telemetry_devices']);
   });
 });


### PR DESCRIPTION
#115

`useview_telemetry_metrics` uses a long-format with one row per telemetry metric with columns for min, max, sum, count, sumsqr. Provides index columns for device_id, telemetry_doc_id, period_start, and user_name.

`useview_telemetry_devices` displays the latest device information for each { deviceId, username } pair. Allows for easily lookup of latest state for a user-device.

Related: https://forum.communityhealthtoolkit.org/t/making-changes-to-cht-couch2pg-view-useview-telemetry/2490/3