### PR TITLE
Use node:10-buster images to workaround "apt update" failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [ push]
 jobs:
   build-and-test:
     name: Build cht-couch2pg
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 15
 
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [ push]
 jobs:
   build-and-test:
     name: Build cht-couch2pg
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
 
     strategy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN npm ci
 #Test build
 FROM base_couch2pg_build AS test-couch2pg
 WORKDIR /app
+RUN apt install git
 RUN git submodule update --init
 RUN npm i -g grunt-cli
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN npm ci
 #Test build
 FROM base_couch2pg_build AS test-couch2pg
 WORKDIR /app
-RUN apt install git
+RUN apt-get install git --assume-yes
 RUN git submodule update --init
 RUN npm i -g grunt-cli
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 #base Build
 ARG node_version=10
-FROM node:$node_version-buster as base_couch2pg_build
+FROM node:$node_version-buster-slim as base_couch2pg_build
 RUN apt update
 RUN apt dist-upgrade -y
 RUN apt -y install postgresql-client curl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 #base Build
 ARG node_version=10
-FROM node:$node_version as base_couch2pg_build
+FROM node:$node_version-buster as base_couch2pg_build
 RUN apt update
 RUN apt dist-upgrade -y
 RUN apt -y install postgresql-client curl


### PR DESCRIPTION
This PR changes the docker image in the `Dockerfile` from `node:10` to `node:10-buster` 

Fix for #132 